### PR TITLE
Provide run scripts for 2-machine, 2-vm, and 2-network-namespace scen…

### DIFF
--- a/AF_XDP-filter/run.sh
+++ b/AF_XDP-filter/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+ip link set dev enp25s0 xdpgeneric off
+rm -f /sys/fs/bpf/accept_map /sys/fs/bpf/xdp_stats_map
+ip tuntap add mode tun tun0
+ip link set dev tun0 down
+ip link set dev tun0 addr 10.1.0.254/24
+ip link set dev tun0 up
+export LD_LIBRARY_PATH=/usr/local/lib
+./af_xdp_user -S -d enp25s0 -Q 16 --filename ./af_xdp_kern.o

--- a/AF_XDP-filter/runnest.sh
+++ b/AF_XDP-filter/runnest.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+ip link set dev enp1s0 xdpgeneric off
+rm -f /sys/fs/bpf/accept_map /sys/fs/bpf/xdp_stats_map
+ip tuntap add mode tun tun0
+ip link set dev tun0 down
+ip link set dev tun0 addr 10.0.2.254/24
+ip link set dev tun0 up
+export LD_LIBRARY_PATH=/usr/local/lib
+./af_xdp_user -S -d enp1s0 -Q 1 --filename ./af_xdp_kern.o

--- a/AF_XDP-filter/runns.sh
+++ b/AF_XDP-filter/runns.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -x
+ip netns delete ns1
+ip netns delete ns2
+sleep 2
+
+ip netns add ns1
+ip netns add ns2
+
+ip link add veth1 type veth peer name vpeer1
+ip link add veth2 type veth peer name vpeer2
+
+ip link set veth1 up
+ip link set veth2 up
+
+ip link set vpeer1 netns ns1
+ip link set vpeer2 netns ns2
+
+ip link add br0 type bridge
+ip link set br0 up
+
+ip link set veth1 master br0
+ip link set veth2 master br0
+
+ip addr add 10.10.0.1/16 dev br0
+
+iptables -P FORWARD ACCEPT
+iptables -F FORWARD
+
+
+ip netns exec ns2 ./runns2.sh &
+ip netns exec ns1 ./runns1.sh
+
+wait

--- a/AF_XDP-filter/runns1.sh
+++ b/AF_XDP-filter/runns1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+ip link set lo up
+ip link set vpeer1 up
+ip addr add 10.10.0.10/16 dev vpeer1
+sleep 6
+ping -c 10 10.10.0.20
+

--- a/AF_XDP-filter/runns2.sh
+++ b/AF_XDP-filter/runns2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -x
+
+ip link set lo up
+ip link set vpeer2 up
+ip addr add 10.10.0.20/16 dev vpeer2
+ip link set dev vpeer2 xdpgeneric off
+ip tuntap add mode tun tun0
+ip link set dev tun0 down
+ip link set dev tun0 addr 10.10.0.30/24
+ip link set dev tun0 up
+
+mount -t bpf bpf /sys/fs/bpf
+df /sys/fs/bpf
+ls -l /sys/fs/bpf
+rm -f /sys/fs/bpf/accept_map /sys/fs/bpf/xdp_stats_map
+if [[ -z "${LEAVE}" ]]
+then 
+  export LD_LIBRARY_PATH=/usr/local/lib
+  ./af_xdp_user -S -d vpeer2 -Q 1 --filename ./af_xdp_kern.o &
+  ns2_pid=$!
+  sleep 20
+  kill -INT ${ns2_pid}
+fi 
+wait

--- a/AF_XDP-filter/runvm.sh
+++ b/AF_XDP-filter/runvm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+ip link set dev enp1s0 xdpgeneric off
+rm -f /sys/fs/bpf/accept_map /sys/fs/bpf/xdp_stats_map
+ip tuntap add mode tun tun0
+ip link set dev tun0 down
+ip link set dev tun0 addr 192.168.122.254/24
+ip link set dev tun0 up
+export LD_LIBRARY_PATH=/usr/local/lib
+./af_xdp_user -S -d enp1s0 -Q 1 --filename ./af_xdp_kern.o


### PR DESCRIPTION
…arios

This PR provides scripts to configure networking and run the filter. runns1.sh and runns2.sh are internal helper scripts; run.sh, runvm.sh, and runnest.sh run the filter on a server node with a view to allowing a client program such as `ping` or `ssh` to run on a client node; and `runns.sh` is a script to exercise a filtered `ping` between network namespaces on a single node.